### PR TITLE
bugfix:修复\think\testing\InteractsWithPages::$crawler未被实例化的bug

### DIFF
--- a/src/CrawlerTrait.php
+++ b/src/CrawlerTrait.php
@@ -20,6 +20,7 @@ use think\facade\Response;
 use think\facade\Route;
 use think\helper\Arr;
 use think\helper\Str;
+use think\response\View;
 
 trait CrawlerTrait
 {
@@ -80,6 +81,9 @@ trait CrawlerTrait
         try {
             Route::setRequest($request);
             $response = App::bindTo('request', $request)->run();
+            if ($response instanceof View) {
+                $this->crawler = new \Symfony\Component\DomCrawler\Crawler($response->getContent(), $this->currentUri);
+            }
         } catch (Exception $e) {
             $response = Error::getExceptionHandler()->render($e);
         } catch (\Throwable $e) {


### PR DESCRIPTION
bugfix:修复\think\testing\CrawlerTrait::call() 没有实例化\Symfony\Component\DomCrawler\Crawler,导致\think\testing\InteractsWithPages::$crawler为空值的bug